### PR TITLE
Faster implementation without bigint.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,2 @@
+Ossama Hjaji <ossama-hjaji@live.fr>
+Mara Bos <m-ou.se@m-ou.se>

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,34 +1,4 @@
 [[package]]
 name = "add-one"
 version = "0.1.2"
-dependencies = [
- "num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
-[[package]]
-name = "num-bigint"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[metadata]
-"checksum num-bigint 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3eceac7784c5dc97c2d6edf30259b4e153e6e2b42b3c85e9a6e9f45d06caef6e"
-"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
-"checksum num-traits 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "630de1ef5cc79d0cdd78b7e33b81f083cbfe90de0f4b2b2f07f905867c70e9fe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,3 @@ description = "Adds one to a number"
 version = "0.1.2"
 authors = ["02sh"]
 license = "MIT"
-
-[dependencies]
-num-bigint = "0.2"
-num-traits = "^0.2"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 02sh
+Copyright (c) 2018 02sh and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,94 @@
-extern crate num_bigint;
+use std::io;
 
-use num_bigint::{BigInt, ParseBigIntError};
+pub fn add_one<T: io::Write>(digits: &[u8], output: &mut T) -> Result<(), io::Error> {
+    // Parse the leading '-' for negative numbers.
+    let (minus, digits) = match digits.split_first() {
+        Some((b'-', digits)) => (true, digits), // Negative number
+        _ => (false, digits),
+    };
 
-pub fn add_one(number_str: &str) -> Result<BigInt, ParseBigIntError> {
-    number_str.parse::<BigInt>().map(|n| n + 1)
+    // Validate (ASCII) digits.
+    if digits.is_empty() || !digits.iter().all(u8::is_ascii_digit) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput.into(),
+            "Invalid characters in input".to_string()
+        ));
+    }
+
+    // Remove any leading zeros.
+    let digits = &digits[digits.iter().position(|&c| c != b'0').unwrap_or(digits.len())..];
+
+    // Find any trailing 9's (when positive) or 0's (when negative) which will carry the carry bit.
+    let (prefix, trailing) = digits.split_at(
+        digits.iter()
+            .rposition(|&c| c != if minus { b'0' } else { b'9' })
+            .map_or(0, |x| x + 1) // The position *after* the last non-nine/zero.
+    );
+
+    if let Some((&digit, prefix)) = prefix.split_last() {
+        // The last digit before that will have to be incremented/decremented,
+        // and anything before it is left unchanged.
+        let new_digit = if minus {
+            if prefix.is_empty() && trailing.is_empty() && digit == b'1' {
+                // Special case for -1: Result is no longer negative.
+                return output.write_all(b"0");
+            }
+            output.write_all(b"-")?;
+            digit - 1
+        } else {
+            digit + 1
+        };
+        // Write prefix, unchanged.
+        output.write_all(prefix)?;
+        // Write changed digit, unless it became a leading zero.
+        if !prefix.is_empty() || new_digit != b'0' {
+            output.write_all(&[new_digit])?;
+        }
+    } else {
+        output.write_all(b"1")?;
+    }
+    for _ in 0..trailing.len() {
+        output.write_all(if minus { b"9" } else { b"0" })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn add_one_test() {
+    fn test(num: &str, result: &str) {
+        use std::str::from_utf8;
+        let mut s = Vec::new();
+        add_one(num.as_bytes(), &mut s).unwrap();
+        assert_eq!(from_utf8(&s).unwrap(), result);
+    }
+    test("1234", "1235");
+    test("0", "1");
+    test("9", "10");
+    test("19", "20");
+    test("99", "100");
+    test("99988999", "99989000");
+    test("99999999", "100000000");
+    test("0001234", "1235");
+    test("-9", "-8");
+    test("-10", "-9");
+    test("-100", "-99");
+    test("-0100", "-99");
+    test("-1100", "-1099");
+    test("-01100", "-1099");
+    test("-1", "0");
+    test("-001", "0");
+    test("-0", "1");
+    test("-000", "1");
+    test(
+        "1256146513513224524524524524522452165841613615616516516",
+        "1256146513513224524524524524522452165841613615616516517"
+    );
+    test(
+        "1237801293471034709342345050491203491230949139249123949999999",
+        "1237801293471034709342345050491203491230949139249123950000000"
+    );
+    test(
+        "-1237801293471034709342345050491203491230949139249123940000000",
+        "-1237801293471034709342345050491203491230949139249123939999999"
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub fn add_one<T: io::Write>(digits: &[u8], output: &mut T) -> Result<(), io::Er
     // Validate (ASCII) digits.
     if digits.is_empty() || !digits.iter().all(|&c| c >= b'0' && c <= b'9') {
         return Err(io::Error::new(
-            io::ErrorKind::InvalidInput.into(),
+            io::ErrorKind::InvalidInput,
             "Invalid characters in input".to_string()
         ));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub fn add_one<T: io::Write>(digits: &[u8], output: &mut T) -> Result<(), io::Er
     Ok(())
 }
 
-#[cfg(test)]
+#[test]
 fn add_one_test() {
     fn test(num: &str, result: &str) {
         use std::str::from_utf8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,12 @@ use std::io;
 pub fn add_one<T: io::Write>(digits: &[u8], output: &mut T) -> Result<(), io::Error> {
     // Parse the leading '-' for negative numbers.
     let (minus, digits) = match digits.split_first() {
-        Some((b'-', digits)) => (true, digits), // Negative number
+        Some((&b'-', digits)) => (true, digits), // Negative number
         _ => (false, digits),
     };
 
     // Validate (ASCII) digits.
-    if digits.is_empty() || !digits.iter().all(u8::is_ascii_digit) {
+    if digits.is_empty() || !digits.iter().all(|&c| c >= b'0' && c <= b'9') {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput.into(),
             "Invalid characters in input".to_string()

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate add_one;
 use add_one::add_one;
 use std::env;
 use std::io::stdout;
+use std::process::exit;
 
 fn main() {
     let mut args = env::args();
@@ -26,6 +27,9 @@ fn main() {
 
     match add_one(input_str.as_bytes(), &mut stdout()) {
         Ok(()) => println!(),
-        Err(e) => eprintln!("Error: {}", e),
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            exit(1);
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
-extern crate num_bigint;
-extern crate num_traits;
 extern crate add_one;
 
-use std::env;
 use add_one::add_one;
+use std::env;
+use std::io::stdout;
 
 fn main() {
     let mut args = env::args();
@@ -25,29 +24,8 @@ fn main() {
         return;
     };
 
-    let output_str = add_one(&input_str);
-
-    match output_str {
-        Ok(v) => println!("{}", v),
-        Err(e) => eprintln!("Bad Input: {}", e),
+    match add_one(input_str.as_bytes(), &mut stdout()) {
+        Ok(()) => println!(),
+        Err(e) => eprintln!("Error: {}", e),
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use num_traits::FromPrimitive; 
-    use num_bigint::BigInt;
-    use super::*; 
-    #[test] 
-    fn it_works() {
-        assert_eq!(add_one("2").unwrap(), BigInt::from_i64(3).unwrap());
-        assert_eq!(add_one("-11").unwrap(), BigInt::from_i64(-10).unwrap());
-        assert_eq!(
-            add_one("1256146513513224524524524524522452165841613615616516516").unwrap(),
-            "1256146513513224524524524524522452165841613615616516517"
-                .parse::<BigInt>()
-                .unwrap()
-        );
-    }
-}
-


### PR DESCRIPTION
Since incrementing a (decimal) number leaves most of it unchanged, it's much faster to work on the decimal digits itself, instead of converting to binary and back.

It is of course very important `add-one` is fast and efficient, so we can call it repeatedly to increment more than one. ;)

Running the testcase on both the original bigint version, and this decimal implementation:

    add_one_bigint  ... bench:       5,571 ns/iter (+/- 101)
    add_one_decimal ... bench:       1,658 ns/iter (+/- 159)

The difference is much more dramatic for extremely large numbers (e.g. of several gigabytes).