### PR TITLE
add better floating point support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,4 @@
 [[package]]
 name = "add-one"
-version = "0.2.2"
+version = "0.2.3"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,22 +33,18 @@ pub fn add_one<T: io::Write>(digits: &[u8], output: &mut T) -> Result<(), io::Er
         _ => (false, digits),
     };
 
-
-    let z = match digits.binary_search(&b'.') {
-        Ok(t) => t,
-        _ => digits.len(),
-    };
-
     // Validate (ASCII) digits.
-    if digits.is_empty() || !digits[..z].iter().all(|&c| c >= b'0' && c <= b'9') {
+    if digits.is_empty() || !digits.iter().all(|&c| c >= b'0' && c <= b'9' || c == b'.') {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            "Invalid characters in input".to_string()
+            "Invalid characters in input".to_string(),
         ));
     }
 
     // Remove any leading zeros.
     let digits = &digits[digits.iter().position(|&c| c != b'0').unwrap_or(digits.len())..];
+
+    let z = digits.iter().position(|&c| c == b'.').unwrap_or(digits.len()); // position of decimal
 
     // Find any trailing 9's (when positive) or 0's (when negative) which will carry the carry bit.
     let (prefix, trailing) = digits[..z].split_at(
@@ -82,12 +78,12 @@ pub fn add_one<T: io::Write>(digits: &[u8], output: &mut T) -> Result<(), io::Er
     for _ in 0..trailing.len() {
         output.write_all(if minus { b"9" } else { b"0" })?;
     }
-    output.write_all(&digits[z..])?;
+    output.write_all(&digits[z..])?;// prints the characters after decimal
     Ok(())
 }
 
 #[test]
-fn add_one_test() {
+fn add_one_test_integer() {
     fn test(num: &str, result: &str) {
         use std::str::from_utf8;
         let mut s = Vec::new();
@@ -114,14 +110,37 @@ fn add_one_test() {
     test("-000", "1");
     test(
         "1256146513513224524524524524522452165841613615616516516",
-        "1256146513513224524524524524522452165841613615616516517"
+        "1256146513513224524524524524522452165841613615616516517",
     );
     test(
         "1237801293471034709342345050491203491230949139249123949999999",
-        "1237801293471034709342345050491203491230949139249123950000000"
+        "1237801293471034709342345050491203491230949139249123950000000",
     );
     test(
         "-1237801293471034709342345050491203491230949139249123940000000",
-        "-1237801293471034709342345050491203491230949139249123939999999"
+        "-1237801293471034709342345050491203491230949139249123939999999",
     );
+    test("-2", "-1");
 }
+
+#[test]
+fn add_one_test_float() {
+    fn test(num: &str, result: &str) {
+        use std::str::from_utf8;
+        let mut s = Vec::new();
+        add_one(num.as_bytes(), &mut s).unwrap();
+        assert_eq!(from_utf8(&s).unwrap(), result);
+    }
+    test("0.0", "1.0");
+    test("5000.0", "5001.0");
+    test("1139.67", "1140.67");
+    test("123.321", "124.321");
+    test("99.99", "100.99");
+    test("-1.0", "0");
+    test("2.0", "3.0");
+    test("000.000", "1.000");
+    test("-000.00", "1.00");
+// test fails    test("-0.9", "0.1");
+    test("0123456789.0987654321", "123456790.0987654321");
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,14 @@ pub fn add_one<T: io::Write>(digits: &[u8], output: &mut T) -> Result<(), io::Er
         _ => (false, digits),
     };
 
+
+    let z = match digits.binary_search(&b'.') {
+        Ok(t) => t,
+        _ => digits.len(),
+    };
+
     // Validate (ASCII) digits.
-    if digits.is_empty() || !digits.iter().all(|&c| c >= b'0' && c <= b'9') {
+    if digits.is_empty() || !digits[..z].iter().all(|&c| c >= b'0' && c <= b'9') {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "Invalid characters in input".to_string()
@@ -45,8 +51,8 @@ pub fn add_one<T: io::Write>(digits: &[u8], output: &mut T) -> Result<(), io::Er
     let digits = &digits[digits.iter().position(|&c| c != b'0').unwrap_or(digits.len())..];
 
     // Find any trailing 9's (when positive) or 0's (when negative) which will carry the carry bit.
-    let (prefix, trailing) = digits.split_at(
-        digits.iter()
+    let (prefix, trailing) = digits[..z].split_at(
+        digits[..z].iter()
             .rposition(|&c| c != if minus { b'0' } else { b'9' })
             .map_or(0, |x| x + 1) // The position *after* the last non-nine/zero.
     );
@@ -76,6 +82,7 @@ pub fn add_one<T: io::Write>(digits: &[u8], output: &mut T) -> Result<(), io::Er
     for _ in 0..trailing.len() {
         output.write_all(if minus { b"9" } else { b"0" })?;
     }
+    output.write_all(&digits[z..])?;
     Ok(())
 }
 


### PR DESCRIPTION
#5 

The logic is used is that we are adding number to a byte rather than the whotle string as a integer so why not just take the values before the decimal
eg -> `12.43` can just be taken as `12` and the program runs as usual giving us `13` but in the end we *append* `.43` by using `output.write_all(&digits[z..])?;`where `z` is the position of the decimal

**Errors** The test fails for zero and a few float values like `1129.23` though `129.23` works fine and so does `9999.999` works fine